### PR TITLE
Handle product deletion by zeroing quantity

### DIFF
--- a/domain/repository/productManager.js
+++ b/domain/repository/productManager.js
@@ -32,7 +32,8 @@ async function removeProductFromUser(userId, { name, quantity, quality }) {
   if (!product) throw new Error('Product not found');
 
   if (product.quantity <= quantity) {
-    await findByIdAndDelete(product._id);
+    await Product.findByIdAndDelete(product._id);
+    product.quantity = 0;
   } else {
     product.quantity -= quantity;
     await product.save();


### PR DESCRIPTION
## Summary
- Set product quantity to 0 and use `Product.findByIdAndDelete` when removing a product entirely.

## Testing
- `npm test` (fails: `run: not found`)


------
https://chatgpt.com/codex/tasks/task_e_68ab690aef08832488465e4d28353f53